### PR TITLE
fix: Shared file can be downloaded now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Telegram Drive is a powerful utility that enables you to organise your telegram 
 
 ```bash
 curl -sSL https://instl.vercel.app/tgdrive/teldrive/linux | bash
+
+#Use command below if above fails to identify cpu arch only works for linux systems
+
+curl -s https://sh-install.vercel.app/tgdrive/teldrive?move=1 | bash
 ```
 
 #### Windows

--- a/pkg/services/file.go
+++ b/pkg/services/file.go
@@ -735,7 +735,8 @@ func (fs *FileService) GetFileStream(c *gin.Context, download bool, sharedFile *
 
 	} else {
 
-		session = &models.Session{UserId: sharedFile.UserID}
+		fs.db.Model(&models.Session{}).Where("user_id = ?", sharedFile.UserID).First(&session)
+
 	}
 
 	file := &schemas.FileOutFull{}


### PR DESCRIPTION
I was trying to share file and downloding from teledrive. But an error occured after I clicked the download button.

![response](https://bucket.voidval.com/upload/2024/12/80ac7fa5b356ec6a50219ab73b3933f9.png)


The following is my server information.

Server Version:
 [1.5.6](https://github.com/tgdrive/teldrive/commits/1.5.6)

I located the issue happend in [teldrive/pkg/services/file.go line 842](https://github.com/tgdrive/teldrive/blob/4248603f58a62734080501883e4474ffc66b7505/pkg/services/file.go#L842)

Client couldn't be authorized becasue of [here](https://github.com/tgdrive/teldrive/blob/4248603f58a62734080501883e4474ffc66b7505/pkg/services/file.go#L738)
and then error occured.

I replace the code `session = &models.Session{UserId: sharedFile.UserID}` with `fs.db.Model(&models.Session{}).Where("user_id = ?", sharedFile.UserID).First(&session)` and it works well now.