### PR TITLE
feat: add HEIF, HEIC, and WebP to  image extensions

### DIFF
--- a/internal/category/category.go
+++ b/internal/category/category.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	documentExtensions = []string{"doc", "docx", "ppt", "pptx", "pps", "ppsx", "odt", "xls", "xlsx", "csv", "pdf", "txt"}
-	imageExtensions    = []string{"jpg", "jpeg", "png", "gif", "bmp", "svg"}
+	imageExtensions    = []string{"jpg", "jpeg", "png", "gif", "bmp", "svg", "webp", "heif", "heic"}
 	videoExtensions    = []string{"mp4", "webm", "mov", "avi", "m4v", "flv", "wmv", "mkv", "mpg", "mpeg", "m2v", "mpv"}
 	audioExtensions    = []string{"mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "aiff", "ape", "alac", "opus", "pcm"}
 	archiveExtensions  = []string{"zip", "rar", "tar", "gz", "7z", "iso", "dmg", "pkg"}


### PR DESCRIPTION
## Summary
This PR updates Teldrive’s file type detection to properly recognize modern image formats.

## Changes
- Added `webp`, `heif`, and `heic` to the `imageExtensions` array.

## Context
Previously, files with `.webp`, `.heif`, or `.heic` extensions were categorized as "others" instead of "images".  
This caused incorrect grouping in file views and could confuse users.

## Benefits
- Ensures modern image formats from smartphones and cameras are correctly identified as images.
- Improves file organization and user experience.