### PR TITLE
feat: add xz and tgz to supported archive extensions

### DIFF
--- a/internal/category/category.go
+++ b/internal/category/category.go
@@ -21,7 +21,7 @@ var (
 	imageExtensions    = []string{"jpg", "jpeg", "png", "gif", "bmp", "svg"}
 	videoExtensions    = []string{"mp4", "webm", "mov", "avi", "m4v", "flv", "wmv", "mkv", "mpg", "mpeg", "m2v", "mpv"}
 	audioExtensions    = []string{"mp3", "wav", "ogg", "m4a", "flac", "aac", "wma", "aiff", "ape", "alac", "opus", "pcm"}
-	archiveExtensions  = []string{"zip", "rar", "tar", "gz", "7z", "iso", "dmg", "pkg"}
+	archiveExtensions  = []string{"zip", "rar", "tar", "gz", "7z", "iso", "dmg", "pkg", "xz", "tgz"}
 )
 
 func GetCategory(fileName string) Category {


### PR DESCRIPTION
## Summary
This PR updates Teldrive’s file type detection to recognize `.xz` and `.tgz` archives.

## Changes
- Added `xz` and `tgz` to the `archiveExtensions` array.

## Context
Previously, `.xz` and `.tgz` files were categorized as "others" instead of "archives".  
These formats are widely used for distributing software packages and backups, especially in Linux/Unix environments.

## Benefits
- Ensures correct categorization of `.xz` and `.tgz` archives.
- Improves compatibility for developers and users handling compressed tarballs.