### PR TITLE
fix: add created_at column to channels table (fixes #536)

### DIFF
--- a/internal/database/migrations/20260215120000_add_channel_created_at.sql
+++ b/internal/database/migrations/20260215120000_add_channel_created_at.sql
@@ -1,0 +1,15 @@
+-- Add created_at column to channels table
+ALTER TABLE teldrive.channels ADD COLUMN IF NOT EXISTS created_at timestamptz;
+
+-- Set created_at for existing channels that don't have it
+-- Use the earliest file created_at as reference, or a reasonable default if no files
+UPDATE teldrive.channels c
+SET created_at = COALESCE(
+    (SELECT MIN(f.created_at) FROM teldrive.files f WHERE f.channel_id = c.channel_id),
+    NOW() - INTERVAL '1 day'
+)
+WHERE c.created_at IS NULL;
+
+-- Make column not-nullable and set default for new records
+ALTER TABLE teldrive.channels ALTER COLUMN created_at SET NOT NULL;
+ALTER TABLE teldrive.channels ALTER COLUMN created_at SET DEFAULT timezone('utc'::text,now());

--- a/pkg/models/channel.go
+++ b/pkg/models/channel.go
@@ -1,8 +1,13 @@
 package models
 
+import (
+	"time"
+)
+
 type Channel struct {
-	ChannelId   int64  `gorm:"type:bigint;primaryKey"`
-	ChannelName string `gorm:"type:text"`
-	UserId      int64  `gorm:"type:bigint;"`
-	Selected    bool   `gorm:"type:boolean;"`
+	ChannelId   int64     `gorm:"type:bigint;primaryKey"`
+	ChannelName string    `gorm:"type:text"`
+	UserId      int64     `gorm:"type:bigint"`
+	Selected    bool      `gorm:"type:boolean"`
+	CreatedAt   time.Time `gorm:"type:timestamptz"`
 }


### PR DESCRIPTION
## Summary
- Adds `CreatedAt` field to the `Channel` model
- Adds migration to add `created_at` column to existing channels table
- Sets `created_at` for existing channels based on their earliest file creation time

This fixes issue #536 where uploading a file without configuring channels causes a 500 error because the code tries to query channels using `created_at` field which didn't exist in the model.