### PR TITLE
fix: add goose markers to migration file

### DIFF
--- a/internal/database/migrations/20260215120000_add_channel_created_at.sql
+++ b/internal/database/migrations/20260215120000_add_channel_created_at.sql
@@ -1,8 +1,6 @@
--- Add created_at column to channels table
+-- +goose Up
 ALTER TABLE teldrive.channels ADD COLUMN IF NOT EXISTS created_at timestamptz;
 
--- Set created_at for existing channels that don't have it
--- Use the earliest file created_at as reference, or a reasonable default if no files
 UPDATE teldrive.channels c
 SET created_at = COALESCE(
     (SELECT MIN(f.created_at) FROM teldrive.files f WHERE f.channel_id = c.channel_id),
@@ -10,6 +8,8 @@ SET created_at = COALESCE(
 )
 WHERE c.created_at IS NULL;
 
--- Make column not-nullable and set default for new records
 ALTER TABLE teldrive.channels ALTER COLUMN created_at SET NOT NULL;
 ALTER TABLE teldrive.channels ALTER COLUMN created_at SET DEFAULT timezone('utc'::text,now());
+
+-- +goose Down
+ALTER TABLE teldrive.channels DROP COLUMN IF EXISTS created_at;


### PR DESCRIPTION
The migration file was missing the required `-- +goose Up/Down` markers which caused the migration to fail.

Fixes the migration error: `failed to parse migration: unexpected state 0`