### PR TITLE
fix(tgc): guard FetchBotInfo against nil user when RunWithAuth returns no error

### DIFF
--- a/internal/tgc/helpers.go
+++ b/internal/tgc/helpers.go
@@ -204,6 +204,15 @@ func FetchBotInfo(ctx context.Context, kvRepo repositories.KVRepository, cache c
 	if err != nil {
 		return nil, err
 	}
+	// Guard against the rare path where RunWithAuth returns nil but the
+	// inner client.Self call never actually populated `user` (for example
+	// when the connection is torn down mid-flight and the gotd middleware
+	// swallows the cancel as a no-op). Dereferencing user.ID / user.Username
+	// below was crashing the whole process because AddBotsToChannel runs
+	// the bot probe inside an errgroup that does not recover panics.
+	if user == nil {
+		return nil, fmt.Errorf("bot self lookup returned no user info")
+	}
 	return &types.BotInfo{ID: user.ID, UserName: user.Username, Token: token}, nil
 }
 


### PR DESCRIPTION
## What

`FetchBotInfo` in `internal/tgc/helpers.go` captures `*tg.User` from the inner Telegram call:

```go
var user *tg.User
// ...
err = RunWithAuth(ctx, client, token, func(ctx context.Context) error {
    var err error
    user, err = client.Self(ctx)
    return err
})
if err != nil {
    return nil, err
}
return &types.BotInfo{ID: user.ID, UserName: user.Username, Token: token}, nil
```

When the underlying connection tears down mid-flight — the `gotd` flood-wait / rate-limit middleware chain can swallow a context cancel as a no-op retry and bubble out `nil` on a later attempt — the callback finishes with `err == nil` while `user` is still `nil`. The final `return` then dereferences `user.ID` / `user.Username` and panics the whole process.

Per #563 the user-visible crash sits right after `[TG] auth.bot_failed error=context canceled`, with the stack ending inside `channel_manager.go:278` (the `info.UserName`-using line right after the `FetchBotInfo` call). `AddBotsToChannel` runs these probes inside an `errgroup` that does not recover panics, so one bad bot tears down the whole teldrive process.

## Fix

Add an explicit nil check on the captured `user` and surface a regular error instead of letting the deref trip the runtime:

```go
if user == nil {
    return nil, fmt.Errorf("bot self lookup returned no user info")
}
return &types.BotInfo{ID: user.ID, UserName: user.Username, Token: token}, nil
```

The caller (`AddBotsToChannel`) already routes `FetchBotInfo` errors through backoff-retry and errgroup aggregation, so the calling goroutine just fails that one bot and the server keeps serving the rest of the fleet instead of panicking the process.

## Not changed

The root-cause investigation on why the middleware swallows the cancel-induced nil response is a separate, deeper fix in the gotd chain (or in the retry logic around `RunWithAuth`). This PR is the minimal defensive guard that turns a crash into a logged error.

Fixes #563