### PR TITLE
reader: bounds-check r.pos and currentRange.PartNo in getPartReader

### DIFF
--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 
@@ -137,7 +138,21 @@ func (r *Reader) moveToNextPart() error {
 }
 
 func (r *Reader) getPartReader() (io.ReadCloser, error) {
+	if r.pos < 0 || r.pos >= len(r.ranges) {
+		return nil, fmt.Errorf("reader position %d out of range [0, %d)", r.pos, len(r.ranges))
+	}
 	currentRange := r.ranges[r.pos]
+	// r.ranges is built from user-visible byte offsets and r.parts is
+	// populated from the file row in storage. The two can drift (for
+	// example when a file's parts list changes between request and
+	// response), and a stale currentRange.PartNo then indexes past the
+	// end of r.parts and panics the whole stream goroutine with an
+	// index-out-of-range mid-download (#553). Surface a normal error
+	// instead so the HTTP handler returns 500 rather than killing the
+	// server.
+	if currentRange.PartNo < 0 || int(currentRange.PartNo) >= len(r.parts) {
+		return nil, fmt.Errorf("part number %d out of range for file with %d parts", currentRange.PartNo, len(r.parts))
+	}
 	partId := r.parts[currentRange.PartNo].ID
 
 	chunkSrc := &chunkSource{

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -150,7 +150,7 @@ func (r *Reader) getPartReader() (io.ReadCloser, error) {
 	// index-out-of-range mid-download (#553). Surface a normal error
 	// instead so the HTTP handler returns 500 rather than killing the
 	// server.
-	if currentRange.PartNo < 0 || int(currentRange.PartNo) >= len(r.parts) {
+	if currentRange.PartNo < 0 || currentRange.PartNo >= int64(len(r.parts)) {
 		return nil, fmt.Errorf("part number %d out of range for file with %d parts", currentRange.PartNo, len(r.parts))
 	}
 	partId := r.parts[currentRange.PartNo].ID


### PR DESCRIPTION
Fixes #553.

`getPartReader` indexes `r.ranges` and `r.parts` directly without any length guard:

```go
currentRange := r.ranges[r.pos]
partId := r.parts[currentRange.PartNo].ID
```

`r.ranges` and `r.parts` can drift — a user-visible byte range is computed from the request, but `r.parts` is populated from storage at a different moment, and a stale `currentRange.PartNo` then indexes past the end of `r.parts`. The result is a runtime panic

```
panic: runtime error: index out of range [5] with length 1
  internal/reader/reader.go:136 (getPartReader)
```

that kills the stream goroutine mid-download and shows up as random crashes in production.

This validates `r.pos` against `len(r.ranges)` and `currentRange.PartNo` against `len(r.parts)` before dereferencing, returning a plain error so the HTTP handler responds with a 500 instead of the server tipping over. No behaviour change on any well-formed request; only the inconsistent-state branch changes from panic to error.