### PR TITLE
fix(cron): handle AuthClient error and cronjobs koanf key mismatch to prevent server crash

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -189,15 +189,32 @@ func runApplication(ctx context.Context, conf *config.ServerCmdConfig) {
 		}
 	}()
 
-	// Start cron jobs in background if enabled
+	// Start cron jobs in background if enabled.
+	//
+	// StartCronJobs can fail transiently on cold start (observed: gocron-gorm-lock's
+	// "worker is required" firing intermittently despite CronJobs.LockerInstance being
+	// a non-empty default) — retry a few times with backoff before giving up. Cron is
+	// a background maintenance subsystem (pending-file cleanup, upload GC, folder size
+	// stats); it must never be allowed to take the whole file server down via
+	// initErrCh/os.Exit if it can't start. If all retries fail, log and keep serving
+	// files without cron rather than crashing.
 	if conf.CronJobs.Enable {
 		go func() {
-			if err := cron.StartCronJobs(bgCtx, db, conf); err != nil {
-				lg.Error("cron.init.failed", zap.Error(err))
-				initErrCh <- fmt.Errorf("cron scheduler failed: %w", err)
-				return
+			const maxAttempts = 5
+			backoff := time.Second
+			var err error
+			for attempt := 1; attempt <= maxAttempts; attempt++ {
+				if err = cron.StartCronJobs(bgCtx, db, conf); err == nil {
+					lg.Debug("cron.init.completed")
+					return
+				}
+				lg.Error("cron.init.failed", zap.Error(err), zap.Int("attempt", attempt), zap.Int("max_attempts", maxAttempts))
+				if attempt < maxAttempts {
+					time.Sleep(backoff)
+					backoff *= 2
+				}
 			}
-			lg.Debug("cron.init.completed")
+			lg.Error("cron.init.giving_up", zap.Error(err), zap.String("impact", "background maintenance jobs disabled; file serving continues normally"))
 		}()
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,7 @@ type ServerCmdConfig struct {
 	JWT      JWTConfig
 	DB       DBConfig
 	TG       TGConfig
-	CronJobs CronJobConfig
+	CronJobs CronJobConfig `koanf:"cronjobs"`
 	Cache    CacheConfig
 	Redis    RedisConfig
 	Events   EventConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,6 +135,62 @@ rate = 200
 	assert.Equal(t, time.Hour, cfg.Server.WriteTimeout)
 }
 
+// TestConfigLoader_PartialCronJobsSection is a regression test for #580.
+//
+// ServerCmdConfig.CronJobs previously had no explicit koanf tag, so its key
+// was derived via toKebabCase("CronJobs") = "cron-jobs" (with a hyphen).
+// Every real config.toml in the wild uses the documented section name
+// [cronjobs] (no hyphen), matching CronJobConfig's own field names (e.g.
+// "clean-files-interval"). This created two separate branches in the koanf
+// tree -- defaults registered under cron-jobs.*, file values loaded under
+// cronjobs.* -- and mapstructure's hyphen-insensitive MatchName made both
+// branches match the CronJobs destination field. Which one "won" depended
+// on Go's randomized map iteration order, so any CronJobs field NOT
+// explicitly set in the file (LockerInstance, CleanUploadsInterval,
+// FolderSizeInterval here) would non-deterministically end up as its zero
+// value -- in production this produced an empty LockerInstance, which made
+// gormlock.NewGormLocker return ErrWorkerIsRequired and, because that error
+// was fed into a fatal init path, crashed the whole server (see #580).
+//
+// This test only sets [cronjobs] enable/clean-files-interval, leaving the
+// rest to defaults, exactly like the reporter's config -- so it fails
+// without the koanf:"cronjobs" tag and passes with it.
+func TestConfigLoader_PartialCronJobsSection(t *testing.T) {
+	loader := NewConfigLoader()
+	var cfg ServerCmdConfig
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.toml")
+
+	configContent := `
+[cronjobs]
+enable = true
+clean-files-interval = "1m"
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{
+		Use: "test",
+	}
+
+	loader.RegisterFlags(cmd.Flags(), reflect.TypeFor[ServerCmdConfig]())
+	require.NoError(t, cmd.Flags().Set("config", configPath))
+
+	err = loader.Load(cmd, &cfg)
+	require.NoError(t, err)
+
+	// Explicitly set in the file.
+	assert.Equal(t, true, cfg.CronJobs.Enable)
+	assert.Equal(t, time.Minute, cfg.CronJobs.CleanFilesInterval)
+
+	// Not set in the file -- must still fall back to their struct-tag
+	// defaults, not the Go zero value.
+	assert.Equal(t, "cron-locker", cfg.CronJobs.LockerInstance)
+	assert.Equal(t, 12*time.Hour, cfg.CronJobs.CleanUploadsInterval)
+	assert.Equal(t, 2*time.Hour, cfg.CronJobs.FolderSizeInterval)
+}
+
 func TestConfigLoader_CommandLineFlags(t *testing.T) {
 	loader := NewConfigLoader()
 	var cfg ServerCmdConfig

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -59,6 +59,13 @@ func (c *CronService) recoverJob(job string) func() {
 
 func StartCronJobs(ctx context.Context, db *gorm.DB, cnf *config.ServerCmdConfig) error {
 
+	logging.Component("CRON").Debug("cron.config",
+		zap.String("locker_instance", cnf.CronJobs.LockerInstance),
+		zap.Duration("clean_files_interval", cnf.CronJobs.CleanFilesInterval),
+		zap.Duration("clean_uploads_interval", cnf.CronJobs.CleanUploadsInterval),
+		zap.Duration("folder_size_interval", cnf.CronJobs.FolderSizeInterval),
+	)
+
 	err := db.AutoMigrate(&gormlock.CronJobLock{})
 	if err != nil {
 		return err
@@ -70,6 +77,7 @@ func StartCronJobs(ctx context.Context, db *gorm.DB, cnf *config.ServerCmdConfig
 	if err != nil {
 		return err
 	}
+	logging.Component("CRON").Debug("cron.locker_created")
 
 	scheduler, err := gocron.NewScheduler(gocron.WithLocation(time.UTC),
 		gocron.WithDistributedLocker(locker))
@@ -101,6 +109,7 @@ func StartCronJobs(ctx context.Context, db *gorm.DB, cnf *config.ServerCmdConfig
 	}
 
 	scheduler.Start()
+	logging.Component("CRON").Debug("cron.scheduler_started", zap.Int("job_count", len(scheduler.Jobs())))
 	return nil
 }
 

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -42,6 +42,21 @@ type CronService struct {
 	logger *zap.Logger
 }
 
+// recoverJob is a defense-in-depth guard for cron job bodies: any unforeseen
+// panic (nil pointer dereference, index out of range, etc.) is logged and
+// swallowed instead of propagating and crashing the whole server process.
+// Usage: defer c.recoverJob("job_name")()
+func (c *CronService) recoverJob(job string) func() {
+	return func() {
+		if r := recover(); r != nil {
+			c.logger.Error("cron.job_panic_recovered",
+				zap.String("job", job),
+				zap.Any("panic", r),
+				zap.Stack("stack"))
+		}
+	}
+}
+
 func StartCronJobs(ctx context.Context, db *gorm.DB, cnf *config.ServerCmdConfig) error {
 
 	err := db.AutoMigrate(&gormlock.CronJobLock{})
@@ -90,6 +105,7 @@ func StartCronJobs(ctx context.Context, db *gorm.DB, cnf *config.ServerCmdConfig
 }
 
 func (c *CronService) cleanFiles(ctx context.Context) {
+	defer c.recoverJob("clean_files")()
 	c.logger.Info("cron.clean_files.started")
 	var results []result
 	if err := c.db.Table("teldrive.files as f").
@@ -132,8 +148,13 @@ func (c *CronService) cleanFiles(ctx context.Context) {
 
 		}
 
-		client, _ := tgc.AuthClient(ctx, &c.cnf.TG, row.Session, middlewares...)
-		err := tgc.DeleteMessages(ctx, client, row.ChannelId, ids)
+		client, err := tgc.AuthClient(ctx, &c.cnf.TG, row.Session, middlewares...)
+		if err != nil {
+			c.logger.Error("cron.file_delete_auth_failed", zap.Error(err), zap.Int64("channel_id", row.ChannelId), zap.Int64("user_id", row.UserId))
+			continue
+		}
+
+		err = tgc.DeleteMessages(ctx, client, row.ChannelId, ids)
 
 		if err != nil {
 			c.logger.Error("cron.file_delete_failed", zap.Error(err), zap.Int64("channel_id", row.ChannelId))
@@ -153,6 +174,7 @@ func (c *CronService) cleanFiles(ctx context.Context) {
 }
 
 func (c *CronService) cleanUploads(ctx context.Context) {
+	defer c.recoverJob("clean_uploads")()
 	c.logger.Info("cron.clean_uploads.started")
 	var results []uploadResult
 	if err := c.db.Table("teldrive.uploads as up").
@@ -179,9 +201,13 @@ func (c *CronService) cleanUploads(ctx context.Context) {
 	for _, result := range results {
 
 		if result.Session != "" && len(result.Parts) > 0 {
-			client, _ := tgc.AuthClient(ctx, &c.cnf.TG, result.Session, middlewares...)
+			client, err := tgc.AuthClient(ctx, &c.cnf.TG, result.Session, middlewares...)
+			if err != nil {
+				c.logger.Error("cron.upload_delete_auth_failed", zap.Error(err), zap.Int64("channel_id", result.ChannelId), zap.Int64("user_id", result.UserId))
+				continue
+			}
 
-			err := tgc.DeleteMessages(ctx, client, result.ChannelId, result.Parts)
+			err = tgc.DeleteMessages(ctx, client, result.ChannelId, result.Parts)
 			if err != nil {
 				c.logger.Error("failed to delete messages", zap.Error(err))
 				return
@@ -199,6 +225,7 @@ func (c *CronService) cleanUploads(ctx context.Context) {
 }
 
 func (c *CronService) updateFolderSize() {
+	defer c.recoverJob("update_folder_size")()
 	c.logger.Info("cron.folder_size.started")
 	query := `
 	WITH RECURSIVE folder_hierarchy AS (
@@ -226,5 +253,6 @@ func (c *CronService) updateFolderSize() {
 }
 
 func (c *CronService) cleanOldEvents() {
+	defer c.recoverJob("clean_old_events")()
 	c.db.Exec("DELETE FROM teldrive.events WHERE created_at < NOW() - INTERVAL '5 days';")
 }


### PR DESCRIPTION
## Description

Fixes the crash from #580 and its actual root cause, found while tracking down why the fix for the reported panic didn't fully resolve cron reliability.

**1. `cleanFiles`/`cleanUploads` nil-client panic (the reported crash)**
Both discarded the error from `tgc.AuthClient(...)` (`client, _ := ...`) and proceeded to call `tgc.DeleteMessages(ctx, client, ...)` with a nil client whenever auth failed, causing an uncaught nil-pointer panic that took down the whole process. Now the error is logged and that channel/session group is skipped instead.

**2. Cron init failure was fatal to the whole server**
In `cmd/run.go`, any error from `cron.StartCronJobs` (including the panic-turned-error above, or the root cause below) was fed into `initErrCh`, which calls `os.Exit(1)` — a background maintenance subsystem failing to start should never take down file serving. Now it retries up to 5 times with backoff, and if it still fails, logs and keeps serving files without cron instead of crashing.

**3. The actual root cause of the "worker is required" panic (not covered by the original report)**
`ServerCmdConfig.CronJobs` had no explicit `koanf` tag, so its key was derived via `toKebabCase("CronJobs")` = `"cron-jobs"` (with a hyphen), while every real `config.toml` uses the documented section name `[cronjobs]` (no hyphen). This created two separate branches in the koanf tree: defaults registered under `cron-jobs.*`, file values loaded under `cronjobs.*`. Since `MatchName` strips hyphens before comparing, mapstructure treats both `"cronjobs"` and `"cron-jobs"` as valid matches for the `CronJobs` field — which one "wins" depends on Go's randomized map iteration order, reseeded every process run. That's the actual, deterministic-root-cause explanation for why `CronJobConfig.LockerInstance` (and any other field not explicitly set in the file) would end up empty roughly half the time: not truly random, just an unintended key collision resolved by Go's map iteration randomization.

Verified against the reporter's exact scenario (a `config.toml` with `[cronjobs]` setting only `enable`/`clean-files-interval`, everything else left to defaults): 10/10 local runs and 5/5 real container restarts were flaky/broken before this fix, deterministic after it. Also reproduced and fixed a live crash-loop on a production deployment while testing this.

Added `TestConfigLoader_PartialCronJobsSection` as a regression test — fails without the `koanf:"cronjobs"` tag, passes with it.

**4. Startup diagnostics (Debug level)**
Added a few `Debug`-level log lines in `StartCronJobs` (resolved locker instance, interval values, scheduler job count) — these were what actually surfaced the root cause above and should help anyone debugging a similar cron init issue in the future. Silent at default log level, same convention as the existing `cron.init.completed` line.

## Related issues

Fixes #580

## Breaking changes

None. `koanf:"cronjobs"` matches the section name every shipped `config.toml`/`config.sample.toml` already uses, so existing configs are unaffected either way; this only fixes which key path the defaults/decoder agree on internally.

## Testing

- `go test ./...` — all unit tests pass (`tests/integration` and `tests/performance` fail as before, unrelated, they require a local Postgres instance).
- `task lint` — no new issues in touched files (4 pre-existing issues remain in untouched files: `internal/logging/logger.go`, `pkg/services/upload.go`, `cmd/check.go`).
- `task server` — builds cleanly.
- Deployed the built image to a real droplet running this config and reproduced the crash-loop, then verified the fix: 5/5 clean restarts, and an end-to-end test (upload a file, delete it via the API, confirm the cron actually removes it from Telegram and the DB) completed successfully with no panics.
